### PR TITLE
Support for documentation only in global scope

### DIFF
--- a/jsdocs/plugins/yamlGenerator.js
+++ b/jsdocs/plugins/yamlGenerator.js
@@ -90,7 +90,7 @@
       references: []
     };
 
-    if (Object.keys(classes).length <= 1) {
+    if (Object.keys(classes).length == 0 || Object.keys(classes).length == 1 && Object.values(classes)[0].items.length <= 1) {
       console.log('Nothing extracted for ' + packageName);
       return;
     }


### PR DESCRIPTION
I noticed that documentation was not generated for Javascript files with functions that where exported only in the global scope. Only if you added at least one other item (like a class other than the global class), did it generate documentation for everything including the global functions.

This was because it checked if there where any classes with documentation other than the global class, but if the global class has items, it should also generate documentation for these items.